### PR TITLE
Added more authentication terms to determine whether account is domain-based

### DIFF
--- a/ADPassMon/ADPassMonAppDelegate.applescript
+++ b/ADPassMon/ADPassMonAppDelegate.applescript
@@ -158,7 +158,7 @@ If you do not know your keychain password, enter your new password in the New an
     -- Check if running in a local account
     on localAccountCheck_(sender)
         set accountLoc to (do shell script "dscl localhost read /Search/Users/$USER AuthenticationAuthority") as string
-        if "NetLogon" is in accountLoc
+        if "Active Directory" is in accountLoc or "NetLogon" is in accountLoc or "LocalCachedUser" is in accountLoc then
             set my isLocalAccount to false
             log "Running under a network account."
         else


### PR DESCRIPTION
Was originally just looking for "Active Directory" in output of `dscl localhost read /Search/Users/$USER AuthenticationAuthority"`. In the previous release, I changed that to "NetLogon" only. Now I am looking either of these or "LocalCachedUser".
