### PR TITLE
Fix for clearing Change Password text field

### DIFF
--- a/ADPassMon/ADPassMonAppDelegate.applescript
+++ b/ADPassMon/ADPassMonAppDelegate.applescript
@@ -1283,6 +1283,9 @@ Enable it now?" with icon 2 buttons {"No","Yes"} default button 2)
 
     -- Open Password Prompt window
     on showPasswordPromptWindow_(sender)
+        set oldPassword's stringValue to "" as string
+        set NewPassword's stringValue to "" as string
+        set VerifyPassword's stringValue to "" as string
         activate
         passwordPromptWindow's makeKeyAndOrderFront_(me)
         set passwordPromptWindow's level to 3


### PR DESCRIPTION
Addresses #40 by simply resetting the `oldPassword`, `NewPassword`, and `VerifyPassword` variables to be blank each time the `showPasswordPromptWindow` function is called.

Since the text boxes should be blank each time the window is called up, the second point about them showing the previously entered value lengths shouldn't matter anymore.
