### PR TITLE
Added code to clear Change Password text boxes when windows loads

### DIFF
--- a/ADPassMon/ADPassMonAppDelegate.applescript
+++ b/ADPassMon/ADPassMonAppDelegate.applescript
@@ -1283,6 +1283,9 @@ Enable it now?" with icon 2 buttons {"No","Yes"} default button 2)
 
     -- Open Password Prompt window
     on showPasswordPromptWindow_(sender)
+        set oldPassword's stringValue to "" as string
+        set NewPassword's stringValue to "" as string
+        set VerifyPassword's stringValue to "" as string
         activate
         passwordPromptWindow's makeKeyAndOrderFront_(me)
         set passwordPromptWindow's level to 3


### PR DESCRIPTION
Redoing pull request to point to Master branch. Fixes an issue where the Change Password dialog would keep previously entered text when reopened. New code just resets the values to blank when the window is called.
